### PR TITLE
point epb alias to correct location

### DIFF
--- a/scripts/_functions.sh
+++ b/scripts/_functions.sh
@@ -231,7 +231,7 @@ setup_hostsfile() {
 }
 
 setup_bash_profile() {
-  ALIAS_INFO="alias epb=\"$DIR/epb\""
+  ALIAS_INFO="alias epb=\"$DIR/../epb\""
 
   if [[ -f "$HOME/.zshrc" ]]; then
     if [[ -n $(confirm "Add epb to profile at ~/.zshrc?") ]]; then


### PR DESCRIPTION
The `epb` script is in root, so the alias in .zshrc/ .bash_profile etc should point there.