### PR TITLE
Update unleash 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,12 @@ Register
 
 #### Toggles / Feature flags
 
-Before you use them, you will need to run some updates on the toggles database:
-
-* Go to the toggles / feature flag db container in docker desktop
-* Run `psql postgresql://unleashed:superSecret30CharacterPassword@epb-feature-flag-db/unleashed`
-* Once you have connected to the database, run:
-```sql
-update environments set enabled = true, protected = false where name = 'default';
-Insert into project_environments (project_id, environment_name) values ('default', 'default');
-```
-* You can now create toggles in the feature flags application found at http://epb-feature-flag/features
+* You can now create toggles in the feature flags application found at http://epb-feature-flag
+* The script in the reset.sh, will set up the feature flag with a few toggles.
+* The upgrade to v7, has resulted in a few changes to how the application works
+* The default environment is no longer functional, instead there is a development 
+and production environment created when a new feature flag is created
+* To turn the feature flag, use the switch in the development environment
 
 ### Make File
 

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -154,8 +154,7 @@ services:
           sleep 1
         done
         sleep 1
-        echo 'Starting Unleash...'
-        yarn run start"
+        echo 'Starting Unleash...'"
 
   epb-feature-flag-db:
     build:

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -50,8 +50,8 @@ else
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('register-api-read-only-mode') ON CONFLICT (name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('development', 'register-api-read-only-mode', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('epb-frontend-data-restrict-user-access') ON CONFLICT (name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'epb-frontend-data-restrict-user-access', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('development', 'epb-frontend-data-restrict-user-access', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('block-address-matching-during-lodgement') ON CONFLICT (name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'block-address-matching-during-lodgement', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('development', 'block-address-matching-during-lodgement', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
 
 fi

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -47,14 +47,13 @@ else
   docker compose exec -T epb-addressing bash -c 'cd /app && RACK_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1 make setup-db'
 
   printf "$GREEN Setting up Feature Flags $CLEAR \n"
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"UPDATE environments set enabled = true where name = 'default';\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"UPDATE environments set protected = false where name = 'default';\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into project_environments (project_id, environment_name) VALUES ('default', 'default');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('register-api-read-only-mode');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'register-api-read-only-mode', true, '[]');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('epb-frontend-data-restrict-user-access');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'epb-frontend-data-restrict-user-access', false, '[]');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('address-matching-during-lodgement');\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'address-matching-during-lodgement', true, '[]');\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into environments (name, type, enabled, protected) values ('default', 'default', true, false)\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into project_environments (project_id, environment_name) VALUES ('default', 'default') ON CONFLICT (project_id, environment_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('register-api-read-only-mode') ON CONFLICT (name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'register-api-read-only-mode', true, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('epb-frontend-data-restrict-user-access') ON CONFLICT (name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'epb-frontend-data-restrict-user-access', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('address-matching-during-lodgement') ON CONFLICT (name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'address-matching-during-lodgement', true, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
 
 fi

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -47,13 +47,11 @@ else
   docker compose exec -T epb-addressing bash -c 'cd /app && RACK_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1 make setup-db'
 
   printf "$GREEN Setting up Feature Flags $CLEAR \n"
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into environments (name, type, enabled, protected) values ('default', 'default', true, false)\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into project_environments (project_id, environment_name) VALUES ('default', 'default') ON CONFLICT (project_id, environment_name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('register-api-read-only-mode') ON CONFLICT (name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'register-api-read-only-mode', true, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('development', 'register-api-read-only-mode', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('epb-frontend-data-restrict-user-access') ON CONFLICT (name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'epb-frontend-data-restrict-user-access', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('address-matching-during-lodgement') ON CONFLICT (name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'address-matching-during-lodgement', true, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('block-address-matching-during-lodgement') ON CONFLICT (name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'address-matching-during-lodgement', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
 
 fi

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -52,6 +52,6 @@ else
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('epb-frontend-data-restrict-user-access') ON CONFLICT (name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'epb-frontend-data-restrict-user-access', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
   docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into features (name) VALUES ('block-address-matching-during-lodgement') ON CONFLICT (name) DO NOTHING;\""
-  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'address-matching-during-lodgement', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
+  docker compose exec -T epb-feature-flag-db bash -c "psql --username unleashed -d unleashed -c \"INSERT into feature_environments (environment, feature_name, enabled, variants) VALUES ('default', 'block-address-matching-during-lodgement', false, '[]') ON CONFLICT (environment, feature_name) DO NOTHING;\""
 
 fi

--- a/unleash.Dockerfile
+++ b/unleash.Dockerfile
@@ -1,3 +1,5 @@
-FROM unleashorg/unleash-server:6.5.0
+FROM unleashorg/unleash-server:7.0.0
 
 COPY ./unleash.js index.js
+
+ENTRYPOINT ["node", "/unleash/index.js"]

--- a/unleash.Dockerfile
+++ b/unleash.Dockerfile
@@ -1,4 +1,4 @@
-FROM unleashorg/unleash-server:7.0.0
+FROM unleashorg/unleash-server:7.5.1
 
 COPY ./unleash.js index.js
 

--- a/unleash.js
+++ b/unleash.js
@@ -1,11 +1,8 @@
-'use strict';
+// ESM version
+import { start } from 'unleash-server';
 
-const unleash = require('unleash-server');
-
-let options = {
-    authentication: {
-        type: "none"
-    }
+const options = {
+  authentication: { type: 'none' }
 };
 
-unleash.start(options);
+await start(options);


### PR DESCRIPTION
As part of EPBR-9100, have updated unleash in dev tools to v7.5.1. as this is deployed in pre-prod and prod
- due to the upgrade, the js script is rewritten in ESM syntax
- updated the toggles set up at the start - as the default env was no longer working and updated them to so they are created in the development environment which is working, also update the address-matching toggle
- have updated the ReadMe to explain the changes 